### PR TITLE
Fix color value of Mercury.

### DIFF
--- a/colors.json
+++ b/colors.json
@@ -1,5 +1,5 @@
 {
-    "Mercury": "#abcdef", 
+    "Mercury": "#ff2b2b", 
     "TypeScript": "#31859c", 
     "PureBasic": "#5a6986", 
     "Objective-C++": "#4886FC", 


### PR DESCRIPTION
I have fixed the color value of the Mercury programming language because it was wrong. I didn't search for another wrong; maybe there may be anothers. Also it may be better to fetch original color values from the official address: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml